### PR TITLE
feat: Add history saving and viewing functionality

### DIFF
--- a/Sources/main.py
+++ b/Sources/main.py
@@ -1,5 +1,5 @@
 import sys
-from PySide6.QtWidgets import *
+from PySide6.QtWidgets import (QApplication, QMainWindow, QDialog, QTextEdit, QVBoxLayout, QMessageBox, QPushButton)
 from PySide6.QtCore import QFile
 from ui import Ui_MainWindow
 
@@ -10,6 +10,7 @@ class MainWindow(QMainWindow):
         self.ui.setupUi(self)
         self.ui.PromptButton.clicked.connect(self.PromptButton_clicked)
         self.ui.CopyButton.clicked.connect(self.CopyButton_clicked)
+        self.ui.HistoryButton.clicked.connect(self.HistoryButton_clicked)
 
     def CopyButton_clicked(self):
         self.ui.plainTextEdit.selectAll()
@@ -32,7 +33,47 @@ class MainWindow(QMainWindow):
         VP = self.ui.Input_VP.text()
         IN = self.ui.Input_IN.text()
         CD = self.ui.Input_CD.text()
-        self.ui.plainTextEdit.setPlainText(f"K-WAIS-IV를 {Age}세 학생에게 시행했는데, FSIQ는 {FSIQ}, VCI는 {VCI}, PRI는 {PRI}, WMI는{WMI}, PSI는 {PSI}로 나타났어. 소검사 환산점수는 각각 토막짜기 {BD}점, 공통성 {SI}점, 숫자 {DS}점, 행렬추론 {MR}점, 어휘 {VC}점, 산수 {AR}점, 동형찾기 {SS}점, 퍼즐 {VP}점, 상식 {IN}점, 기호쓰기 {CD}점이야. 이 수검자의 인지적 특성을 알려줘.")
+        prompt_text = f"K-WAIS-IV를 {Age}세 학생에게 시행했는데, FSIQ는 {FSIQ}, VCI는 {VCI}, PRI는 {PRI}, WMI는{WMI}, PSI는 {PSI}로 나타났어. 소검사 환산점수는 각각 토막짜기 {BD}점, 공통성 {SI}점, 숫자 {DS}점, 행렬추론 {MR}점, 어휘 {VC}점, 산수 {AR}점, 동형찾기 {SS}점, 퍼즐 {VP}점, 상식 {IN}점, 기호쓰기 {CD}점이야. 이 수검자의 인지적 특성을 알려줘."
+        self.ui.plainTextEdit.setPlainText(prompt_text)
+
+        try:
+            with open("history.txt", "a", encoding="utf-8") as f:
+                f.write(prompt_text + "\n")
+        except (IOError, OSError) as e:
+            print(f"Error writing to history.txt: {e}")
+
+    def HistoryButton_clicked(self):
+        try:
+            with open("history.txt", "r", encoding="utf-8") as f:
+                history_content = f.read()
+            
+            if not history_content:
+                QMessageBox.information(self, "기록 보기", "기록이 없습니다.")
+                return
+
+            dialog = QDialog(self)
+            dialog.setWindowTitle("기록 보기")
+            dialog.setGeometry(300, 300, 400, 300) # x, y, width, height
+
+            layout = QVBoxLayout()
+            
+            text_edit = QTextEdit()
+            text_edit.setPlainText(history_content)
+            text_edit.setReadOnly(True)
+            layout.addWidget(text_edit)
+            
+            close_button = QPushButton("닫기")
+            close_button.clicked.connect(dialog.accept)
+            layout.addWidget(close_button)
+            
+            dialog.setLayout(layout)
+            dialog.exec()
+
+        except FileNotFoundError:
+            QMessageBox.information(self, "기록 보기", "기록 파일(history.txt)을 찾을 수 없습니다.")
+        except (IOError, OSError) as e:
+            QMessageBox.warning(self, "오류", f"기록을 불러오는 중 오류가 발생했습니다: {e}")
+
 
 if __name__ == "__main__":
     app = QApplication(sys.argv)

--- a/Sources/ui.py
+++ b/Sources/ui.py
@@ -28,6 +28,9 @@ class Ui_MainWindow(object):
         self.PromptButton = QPushButton(self.centralwidget)
         self.PromptButton.setObjectName(u"PromptButton")
         self.PromptButton.setGeometry(QRect(200, 360, 100, 32))
+        self.HistoryButton = QPushButton(self.centralwidget)
+        self.HistoryButton.setObjectName(u"HistoryButton")
+        self.HistoryButton.setGeometry(QRect(310, 360, 100, 32))
         self.Input_FSIQ = QLineEdit(self.centralwidget)
         self.Input_FSIQ.setObjectName(u"Input_FSIQ")
         self.Input_FSIQ.setGeometry(QRect(100, 90, 113, 21))
@@ -199,7 +202,8 @@ class Ui_MainWindow(object):
         QWidget.setTabOrder(self.Input_VP, self.Input_IN)
         QWidget.setTabOrder(self.Input_IN, self.Input_CD)
         QWidget.setTabOrder(self.Input_CD, self.PromptButton)
-        QWidget.setTabOrder(self.PromptButton, self.plainTextEdit)
+        QWidget.setTabOrder(self.PromptButton, self.HistoryButton)
+        QWidget.setTabOrder(self.HistoryButton, self.plainTextEdit)
         QWidget.setTabOrder(self.plainTextEdit, self.CopyButton)
 
         self.retranslateUi(MainWindow)
@@ -211,6 +215,7 @@ class Ui_MainWindow(object):
     def retranslateUi(self, MainWindow):
         MainWindow.setWindowTitle(QCoreApplication.translate("MainWindow", u"K-WAIS-IV \ubd84\uc11d \ud504\ub86c\ud504\ud2b8 \uc0dd\uc131\uae30", None))
         self.PromptButton.setText(QCoreApplication.translate("MainWindow", u"\ud504\ub86c\ud504\ud2b8 \uc0dd\uc131", None))
+        self.HistoryButton.setText(QCoreApplication.translate("MainWindow", u"\uae30\ub85d \ubcf4\uae30", None)) # 기록 보기
         self.label.setText(QCoreApplication.translate("MainWindow", u"FSIQ", None))
         self.label_2.setText(QCoreApplication.translate("MainWindow", u"VCI", None))
         self.label_3.setText(QCoreApplication.translate("MainWindow", u"PRI", None))

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -1,0 +1,42 @@
+# Manual Testing Guide for History Feature
+
+## Test Case 1: Verify History Saving and Viewing
+
+1.  **Run the application.**
+2.  **Generate First Prompt:**
+    *   Enter some unique data into the input fields (e.g., Age: 30, FSIQ: 100).
+    *   Click the "프롬프트 생성" (Generate Prompt) button.
+    *   Verify the prompt appears in the main text area.
+3.  **Generate Second Prompt:**
+    *   Change the input data to something different (e.g., Age: 45, FSIQ: 110).
+    *   Click the "프롬프트 생성" (Generate Prompt) button again.
+    *   Verify the new prompt appears in the main text area.
+4.  **Check `history.txt` (Optional but Recommended):**
+    *   Open the `history.txt` file (it should be in the same directory as the application or in the `Sources` directory if the application is run from there).
+    *   Verify that it contains the two prompts generated, each on a new line.
+5.  **View History via UI:**
+    *   Click the "기록 보기" (View History) button.
+    *   A dialog window titled "기록 보기" should appear.
+    *   Verify that this dialog displays the two prompts generated earlier. The text should be read-only.
+    *   Click the "닫기" (Close) button in the dialog. The dialog should close.
+6.  **Generate Third Prompt (Post History View):**
+    *   Enter new data (e.g., Age: 22, FSIQ: 95).
+    *   Click the "프롬프트 생성" (Generate Prompt) button.
+7.  **View History Again:**
+    *   Click the "기록 보기" (View History) button again.
+    *   Verify that the dialog now displays all three prompts (the two old ones and the new one).
+    *   Close the dialog.
+
+## Test Case 2: Verify Behavior with No History
+
+1.  **Ensure no `history.txt` file exists.** (Delete it if it was created from previous tests).
+2.  **Run the application.**
+3.  **View History:**
+    *   Click the "기록 보기" (View History) button.
+    *   A message box should appear stating "기록 파일(history.txt)을 찾을 수 없습니다." (History file (history.txt) not found.) or "기록이 없습니다." (No history found) if the file was created but empty by another action. Click OK/Close on the message box.
+4.  **Generate a Prompt:**
+    *   Enter any data and click "프롬프트 생성".
+5.  **View History:**
+    *   Click "기록 보기".
+    *   The dialog should now appear and show the single prompt you just generated.
+    *   Close the dialog.


### PR DESCRIPTION
This commit introduces a feature that allows you to save and view the history of generated prompts.

Changes include:
- Modified `main.py` to append each generated prompt to `history.txt`.
- Added a "기록 보기" (View History) button to the UI.
- Implemented functionality for the "기록 보기" button to display the contents of `history.txt` in a new dialog window.
- Added `TESTING_GUIDE.md` with manual steps to test the new feature.